### PR TITLE
BUGFIX: avg vs. sum

### DIFF
--- a/extract_partners.sh
+++ b/extract_partners.sh
@@ -43,7 +43,7 @@ for var in ${dailyVars}; do
       tmpfile="${basename}_${expname}_${var}_daily_${dt}.nc"
       if [ ! -f  ${workdir}/${tmpfile} ]; then
         cdo selvar,${var} ${inputdir}/ECE_${expname}_${dt}.nc ${workdir}/tmp.nc
-        if [ ${var}=="CP" ] || [ ${var}=="LSP" ]; then 
+        if [ ${var} == "CP" ] || [ ${var} == "LSP" ]; then
           cdo daysum -shifttime,-1sec ${workdir}/tmp.nc ${workdir}/tmp2.nc
         else
           cdo daymean -shifttime,-1sec ${workdir}/tmp.nc ${workdir}/tmp2.nc
@@ -71,13 +71,13 @@ for var in ${monthlyVars}; do
       tmpfile="${basename}_${expname}_${var}_monthly_${dt}.nc"
       if [ ! -f  ${workdir}/${tmpfile} ]; then
         cdo selvar,${var} ${inputdir}/ECE_${expname}_${dt}.nc ${workdir}/tmp.nc
-        if [ ${var}=="CP" ] || [ ${var}=="LSP" ]; then
+        if [ ${var} == "CP" ] || [ ${var} == "LSP" ]; then
           cdo daysum -shifttime,-1sec ${workdir}/tmp.nc ${workdir}/tmp2.nc
         else
           cdo daymean -shifttime,-1sec ${workdir}/tmp.nc ${workdir}/tmp2.nc
         fi
         cdo shifttime,1sec ${workdir}/tmp2.nc ${workdir}/tmp3.nc
-        if [ ${var}=="CP" ] || [ ${var}=="LSP" ]; then
+        if [ ${var} == "CP" ] || [ ${var} == "LSP" ]; then
           cdo monsum ${workdir}/tmp3.nc ${workdir}/tmp4.nc
         else
           cdo monmean ${workdir}/tmp3.nc ${workdir}/tmp4.nc

--- a/fix_daily.sh
+++ b/fix_daily.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Usage
+# Run in output directory
+#
+# fix_daily.sh expname
+
+# version suffix
+suff="v2"
+
+# start and end year
+start_year=1979
+end_year=2015
+
+# filename definitions
+basename="ECE"
+expname=$1  # experiment name
+
+# ECE_O2Q7_SSHF_daily_2010.nc
+
+# ECE_O2Q7_T2M_daily_2010.nc
+# ECE_O2Q7_T_daily_2010.nc
+# ECE_O2Q7_U_daily_2010.nc
+# ECE_O2Q7_V_daily_2010.nc
+# ECE_O2Q7_Z_daily_2010.nc
+# ECE_O2Q7_MSL_daily_2010.nc
+
+# add scale factor to daily instantaneous vars 
+# we summed three hourly fields, per day
+# divide by 4 to get daily
+fixVars="T2M T U V Z MSL"
+for var in ${fixVars}; do
+  for yr in $(seq ${start_year} ${end_year}); do
+    infile="${basename}_${expname}_${var}_daily_${yr}.nc"
+    outfile="${basename}_${expname}_${var}_daily_${yr}_${suff}.nc"
+    if [ -f ${infile} ]; then
+      ncatted -a scale_factor,${var},c,f,0.25 "${infile}"
+      mv "${infile}" "${outfile}"
+      echo "DONE ${outfile}"
+    else
+      echo "ERROR [file missing] ${outfile}"
+    fi
+  done
+done
+
+# add scale factor to daily fluxes
+# we summed three hourly fields, per day
+# divide by 4 to get daily average of 3 hourly fields
+# then by 3 * 60 * 60 to get W/m2
+fixVars="SSHF"
+for var in ${fixVars}; do
+  for yr in $(seq ${start_year} ${end_year}); do
+    infile="${basename}_${expname}_${var}_daily_${yr}.nc"
+    outfile="${basename}_${expname}_${var}_daily_${yr}_${suff}.nc"
+    if [ -f ${infile} ]; then
+      ncatted -a scale_factor,${var},c,f,2.314814814814814e-5 "${infile}"
+      ncatted -a units,${var},o,c,"W m**-2" "${infile}"
+      mv "${infile}" "${outfile}"
+      echo "DONE ${outfile}"
+    else
+      echo "ERROR [file missing] ${outfile}"
+    fi
+  done
+done

--- a/fix_monthly.sh
+++ b/fix_monthly.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Usage
+# Run in output directory
+#
+# fix_monthly.sh expname
+
+# version suffix
+suff="v2"
+
+# start and end year
+start_year=1979
+end_year=2015
+
+# filename definitions
+basename="ECE"
+expname=$1  # experiment name
+
+# those monthly vars should be ok
+fixVars="CP LSP"
+for var in ${fixVars}; do
+  for yr in $(seq ${start_year} ${end_year}); do
+    infile="${basename}_${expname}_${var}_monthly_${yr}.nc" # ECE_ITNV_T2M_monthly_2001.nc
+    outfile="${basename}_${expname}_${var}_monthly_${yr}_v2.nc" # ECE_ITNV_T2M_monthly_2001_v2.nc
+    cp "${infile}" "${outfile}"
+    echo "DONE ${outfile}"
+  done
+done
+
+# add scale factor to monthly instantaneous vars 
+# we summed three hourly fields, first per day, then per month
+# to divide by 4 to get daily, and then by days-per-month to get average 3 hourly
+fixVars="MSL SP T T2M Z U V Q"
+for var in ${fixVars}; do
+  for yr in $(seq ${start_year} ${end_year}); do
+    infile="${basename}_${expname}_${var}_monthly_${yr}.nc" # ECE_ITNV_T2M_monthly_2001.nc
+    outfile="${basename}_${expname}_${var}_monthly_${yr}_${suff}.nc" # ECE_ITNV_T2M_monthly_2001_v2.nc
+    if [ -f ${infile} ]; then
+      cdo divdpm "${infile}" "${outfile}"
+      ncatted -a scale_factor,${var},c,f,0.25 "${outfile}"
+      echo "DONE ${outfile}"
+    else
+      echo "ERROR [file missing] ${outfile}"
+    fi
+  done
+done
+
+# add scale factor to monthly fluxes
+# we summed three hourly fields, first per day, then per month
+# to divide by 4 to get daily, and then by days-per-month to get average 3 hourly
+# then by 3 * 60 * 60 to get W/m2
+fixVars="SLHF SSHF STR SSR TTR TSR"
+for var in ${fixVars}; do
+  for yr in $(seq ${start_year} ${end_year}); do
+    infile="${basename}_${expname}_${var}_monthly_${yr}.nc" # ECE_ITNV_T2M_monthly_2001.nc
+    outfile="${basename}_${expname}_${var}_monthly_${yr}_${suff}.nc" # ECE_ITNV_T2M_monthly_2001_v2.nc
+    if [ -f ${infile} ]; then
+      cdo divdpm "${infile}" "${outfile}"
+      ncatted -a scale_factor,${var},c,f,2.314814814814814e-5 "${outfile}"
+      ncatted -a units,${var},o,c,"W m**-2" "${outfile}"
+      echo "DONE ${outfile}"
+    else
+      echo "ERROR [file missing] ${outfile}"
+    fi
+  done
+done


### PR DESCRIPTION
A typo made the script run monthly and daily sums instead of averages.
It can be fixed by updating metadata or dividing by number of days per
month, and it is not necessary to re-process everything.

See the scripts fix_daily.sh and fix_monthly.sh for implementation.